### PR TITLE
GitHub Action: initial DockerHub registry push logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, development, next ]
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    tags:
+      - 'v*.*.*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          # assumes image named after owner/repository
+          images: |
+            ${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+


### PR DESCRIPTION
Initial attempt at adding a GitHub Action that mirrors DockerHub auto build

Setup
* DockerHub: create access token - in "my account" --> "security" -> "new access token"
* GitHub: for each repository in "settings" -> "secrets" - "new repository secret"  add the following two secrets
  *  DOCKERHUB_TOKEN
  * DOCKERHUB_USERNAME

Once PR is merged into the default ("master" in this case) branch, the "actions" tab in GitHub should show the progress

Note: this initial likely doesn't match the tagging practice

References:
* https://github.com/docker/metadata-action#typeref
* https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
* https://docs.github.com/en/actions/guides/publishing-docker-images
* https://docs.github.com/en/actions/reference/encrypted-secrets
* https://docs.docker.com/docker-hub/access-tokens/